### PR TITLE
Fixed bug in parsing nw name from folder

### DIFF
--- a/src/ismn/filecollection.py
+++ b/src/ismn/filecollection.py
@@ -84,7 +84,7 @@ def _read_station_dir(
             Depth(f.metadata['instrument'].depth.start,
                   f.metadata['instrument'].depth.end))
 
-        network = f.metadata['nw_from_folder'].val
+        network = f.metadata['network'].val
         station = f.metadata['station'].val
 
         filelist.append((network, station, f))

--- a/src/ismn/filehandlers.py
+++ b/src/ismn/filehandlers.py
@@ -644,9 +644,8 @@ class DataFile(IsmnFile):
         if best_meta_for_sensor:
             depth = metadata['instrument'].depth
             metadata = metadata.best_meta_for_depth(depth)
-        
-        metadata.add('nw_from_folder', self.__get_parent_path(self.posix_path), None)
 
         self.metadata = metadata
+        self.metadata.replace('network', self.__get_parent_path(self.posix_path))
 
         return self.metadata

--- a/src/ismn/interface.py
+++ b/src/ismn/interface.py
@@ -109,8 +109,7 @@ class ISMN_Interface:
         self.collection = NetworkCollection(networks)
 
 
-    def __collect_networks(self,
-                           network_names: list = None) -> list:
+    def __collect_networks(self, network_names: list = None) -> list:
         """
         Build Networks and fill them with Stations and Sensors and apply
         according filehandlers from filelist for data reading.

--- a/src/ismn/interface.py
+++ b/src/ismn/interface.py
@@ -110,8 +110,7 @@ class ISMN_Interface:
 
 
     def __collect_networks(self,
-                           network_names: list = None,
-                           nw_from_folder: bool = True):
+                           network_names: list = None) -> list:
         """
         Build Networks and fill them with Stations and Sensors and apply
         according filehandlers from filelist for data reading.
@@ -130,9 +129,6 @@ class ISMN_Interface:
             nw_name, st_name, instrument = f.metadata['network'].val, \
                                            f.metadata['station'].val, \
                                            f.metadata['instrument'].val
-                                           
-            if nw_from_folder:
-                nw_name = f.metadata['nw_from_folder'].val
 
             if nw_name not in networks:
                 networks[nw_name] = Network(nw_name)

--- a/src/ismn/meta.py
+++ b/src/ismn/meta.py
@@ -510,6 +510,24 @@ class MetaData:
         """
         self.metadata.append(MetaVar(name, val, depth))
 
+    def replace(self, name, val, depth: Depth = None):
+        """
+        Replace the value of a MetaVar in the initialized class
+
+        Parameters
+        ----------
+        name: str
+            name of the MetaVar
+        val: new value of the MetaVar
+        """
+        Var = self.__getitem__(name)
+        if not Var is None:
+            self.metadata.remove(Var)
+            self.metadata.append(MetaVar(name, val, depth))
+
+        else:
+            raise MetadataError ("There is no MetaVar with name '{}'".format(name))
+
     def best_meta_for_depth(self, depth):
         """
         For meta variables that have a depth assigned, find the ones that match

--- a/tests/test_filecollection.py
+++ b/tests/test_filecollection.py
@@ -45,8 +45,11 @@ class Test_FileCollectionCeopSepUnzipped(unittest.TestCase):
         # cecks content of file collection
 
         if os.path.split(self.coll.root.path)[1] == 'Data_seperate_files_20170810_20180809':
-            # check that FR_Aqui is in data AND metwork name is network folder
+            # check that FR_Aqui is in data AND network name is network folder
             assert list(self.coll.filelist.keys()) == ['COSMOS', 'FR_Aqui']
+            # check that files are associated to right network name
+            files = [f for f in self.coll.iter_filehandlers(networks='FR_Aqui')]
+            assert files != []
         else:
             assert list(self.coll.filelist.keys()) == ['COSMOS']
 


### PR DESCRIPTION
The name of the network name is parsed from the folder and **replaces** the 'network' metadata value. The problem before was that (ironically, in order to avoid bugs) both names were left in the metadata under 'network' and 'nw_from_folder', and this created a conflict.

To test this fix, I have:

* ran and updated the tests
* ran the notebook with extended data
* ran validations in QA4SM

and it looks like it should be fixed  